### PR TITLE
Update Cargo.toml to specify it as compilerplugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ license = "MIT"
 [lib]
 name = "rustlex"
 crate-type = ["dylib"]
+plugin = true


### PR DESCRIPTION
According to the [Cargo Manifest](http://doc.crates.io/manifest.html):

> ```
# If the target is meant to be a compiler plugin, this field must be set to true
# for cargo to correctly compile it and make it available for all dependencies.
plugin = false
```

This PR adds `plugin = true` to rustlex' `Cargo.toml` to specify it as compiler plugin and make it available to all dependencies. This should also allow projects using rustlex to enable doctests again.